### PR TITLE
Allow auto file size when size set to zero

### DIFF
--- a/siiptool/common/subregion_descriptor.py
+++ b/siiptool/common/subregion_descriptor.py
@@ -144,7 +144,7 @@ class SubRegionDescriptor(object):
                 valid_file = False
             if data_field.Type not in data_types:
                 valid_file = False
-            if data_field.ByteSize <= 0:
+            if data_field.ByteSize < 0:
                 valid_file = False
             if type(data_field.Value) not in [str, int]:
                 valid_file = False

--- a/siiptool/common/subregion_image.py
+++ b/siiptool/common/subregion_image.py
@@ -206,10 +206,14 @@ def create_gen_fv_command(fv_guid, output_fv_file, ffs_file, input_fv_file=None,
 def create_buffer_from_data_field(data_field):
     buffer = None
     if data_field.Type == subrgn_descptr.data_types.FILE:
-        buffer = bytearray(data_field.ByteSize)  # Allocate the buffer
-        with open(data_field.Value, "rb") as DataFile:
-            tmp = DataFile.read(data_field.ByteSize)
-        buffer[:len(tmp)] = tmp  # copy data to the beginning of the buffer
+        if data_field.ByteSize == 0:   # Read the whole file
+            with open(data_field.Value, "rb") as DataFile:
+                buffer = DataFile.read()
+        else:
+            buffer = bytearray(data_field.ByteSize)  # Allocate the buffer
+            with open(data_field.Value, "rb") as DataFile:
+                tmp = DataFile.read(data_field.ByteSize)
+            buffer[:len(tmp)] = tmp  # copy data to the beginning of the buffer
 
     if data_field.Type == subrgn_descptr.data_types.STRING:
         fmt = "{}s".format(data_field.ByteSize)


### PR DESCRIPTION
Allow zero size field to represent auto size field. If the field size is 0 for file and string fields, the whole file will be read and copied to the buffer. 

Signed-off-by: Mohamed ElGohary <mohamedx.elgohary@intel.com>