### PR TITLE
[capsule] Use passed openssl path while checking openssl existence

### DIFF
--- a/siiptool/common/siip_constants.py
+++ b/siiptool/common/siip_constants.py
@@ -7,7 +7,7 @@
 
 """ Tool Version Number """
 
-VERSION = "0.8.0"
+VERSION = "0.8.1"
 
 """Sub-region configuration for different types of code/data
 """

--- a/siiptool/scripts/subregion_capsule.py
+++ b/siiptool/scripts/subregion_capsule.py
@@ -134,15 +134,6 @@ def create_arg_parser():
 
 if __name__ == "__main__":
 
-    # Check if openssl is installed
-    try:
-        p = subprocess.run(['openssl', 'version'],
-                            stdout=subprocess.PIPE,
-                            universal_newlines=True)
-        print("openssl version: {}".format(p.stdout))
-    except:
-        print("OpenSSL is not installed or missing in PATH!\n")
-        exit(2)
 
     parser = create_arg_parser()
     args = parser.parse_args()
@@ -168,6 +159,10 @@ if __name__ == "__main__":
     ):
         print('All-or-none of the certificate files must be provided.')
         exit(2)
+
+    
+    # Check if openssl is installed or at given path
+    utils.check_for_tool('openssl', 'version', tool_path=args.SigningToolPath)
 
     sub_region_fv_file = os.path.join(os.path.curdir, "SubRegionFv.fv")
     sub_region_image_file = os.path.join(os.path.curdir, "SubRegionImage.bin")


### PR DESCRIPTION
Update version to 0.8.1

TEST= remove openssl form PATH and run capsule tool with --signing-tool-path

Signed-off-by: Mohamed ElGohary <mohamedx.elgohary@intel.com>